### PR TITLE
feat: recreate nicolas dev portfolio in astro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# portafolio-personal
+# Portafolio Personal
+
+Réplico la landing page de Nicolás Dev utilizando Astro, Tailwind CSS y GSAP.
+
+## Scripts
+
+```bash
+npm run dev
+npm run build
+npm run preview
+npm run lint
+```
+
+## Tecnologías
+
+- [Astro](https://astro.build)
+- [Tailwind CSS](https://tailwindcss.com)
+- [GSAP](https://greensock.com/gsap/)

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from 'astro/config';
+import tailwind from '@astrojs/tailwind';
+
+export default defineConfig({
+  integrations: [tailwind({
+    applyBaseStyles: false,
+  })],
+  scopedStyleStrategy: 'where'
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "portafolio-personal",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro",
+    "lint": "astro check"
+  },
+  "dependencies": {
+    "astro": "^4.5.16",
+    "gsap": "^3.12.5"
+  },
+  "devDependencies": {
+    "@astrojs/tailwind": "^5.1.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.4.4"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="16" fill="#0A0A0A" />
+  <path
+    d="M20 20H44L32 44L20 20Z"
+    fill="url(#paint0_linear)"
+  />
+  <defs>
+    <linearGradient id="paint0_linear" x1="20" y1="20" x2="44" y2="44" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5B78F6" />
+      <stop offset="1" stop-color="#C084FC" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -1,0 +1,56 @@
+<section id="sobre-mi" class="relative py-28">
+  <div class="mx-auto flex max-w-6xl flex-col gap-16 px-6 lg:flex-row">
+    <div class="lg:w-2/5">
+      <span class="text-xs font-mono uppercase tracking-[0.3em] text-white/40">Acerca de</span>
+      <h2 class="mt-4 text-3xl font-semibold text-white md:text-4xl">Diseñador obsesionado con los detalles</h2>
+      <p class="mt-6 text-sm text-white/60" data-animate="fade-up">
+        Mi enfoque combina motion, diseño de sistemas y desarrollo no-code. Creo experiencias que se sienten vivas y coherentes en todo el journey del usuario.
+      </p>
+      <p class="mt-4 text-sm text-white/60" data-animate="fade-up">
+        Trabajo con equipos distribuidos alrededor del mundo. Me apasiona integrar diseño con métricas de negocio para entregar productos que generan impacto.
+      </p>
+      <div class="mt-8 grid gap-6 rounded-3xl border border-white/10 bg-charcoal/60 p-6">
+        <div class="flex items-center justify-between">
+          <span class="text-xs font-mono uppercase tracking-[0.3em] text-white/40">Herramientas clave</span>
+          <span class="text-xs text-white/40">Figma · Webflow · After Effects</span>
+        </div>
+        <div class="h-px bg-white/10"></div>
+        <div class="flex flex-wrap gap-3 text-xs text-white/60">
+          <span class="rounded-full border border-white/10 bg-white/5 px-3 py-1">Figma</span>
+          <span class="rounded-full border border-white/10 bg-white/5 px-3 py-1">Webflow</span>
+          <span class="rounded-full border border-white/10 bg-white/5 px-3 py-1">Spline</span>
+          <span class="rounded-full border border-white/10 bg-white/5 px-3 py-1">Framer</span>
+          <span class="rounded-full border border-white/10 bg-white/5 px-3 py-1">Notion</span>
+        </div>
+      </div>
+    </div>
+    <div class="lg:w-3/5">
+      <div class="grid gap-6 md:grid-cols-2">
+        <article class="rounded-3xl border border-white/10 bg-charcoal/60 p-6" data-animate="fade-up">
+          <span class="text-xs font-mono uppercase tracking-[0.3em] text-white/40">Manifiesto</span>
+          <p class="mt-4 text-sm text-white/60">
+            Diseño para que las personas entiendan rápido y disfruten el proceso. Apuesto por animaciones funcionales, micro-interacciones que guían y contenidos claros.
+          </p>
+        </article>
+        <article class="rounded-3xl border border-white/10 bg-charcoal/60 p-6" data-animate="fade-up">
+          <span class="text-xs font-mono uppercase tracking-[0.3em] text-white/40">Colaboraciones</span>
+          <p class="mt-4 text-sm text-white/60">
+            He colaborado con equipos de marketing, producto y tecnología. Desde venture studios hasta startups en YC. Comunicación transparente y procesos ágiles.
+          </p>
+        </article>
+        <article class="rounded-3xl border border-white/10 bg-charcoal/60 p-6" data-animate="fade-up">
+          <span class="text-xs font-mono uppercase tracking-[0.3em] text-white/40">Valores</span>
+          <p class="mt-4 text-sm text-white/60">
+            Claridad, consistencia y emoción. Cada proyecto es una oportunidad para construir relaciones duraderas y experiencias que destaquen.
+          </p>
+        </article>
+        <article class="rounded-3xl border border-white/10 bg-charcoal/60 p-6" data-animate="fade-up">
+          <span class="text-xs font-mono uppercase tracking-[0.3em] text-white/40">Educación</span>
+          <p class="mt-4 text-sm text-white/60">
+            Diplomado en Diseño de Experiencias Interactivas · Cursos intensivos de Motion Graphics y Webflow Enterprise.
+          </p>
+        </article>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -1,0 +1,103 @@
+<section id="contacto" class="relative py-28">
+  <div class="mx-auto max-w-6xl px-6">
+    <div class="rounded-[2.5rem] border border-white/10 bg-gradient-to-br from-charcoal via-charcoal to-midnight/80 p-12">
+      <div class="flex flex-col gap-12 lg:flex-row lg:items-center lg:justify-between">
+        <div class="max-w-xl space-y-6">
+          <span class="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-mono uppercase tracking-[0.4em] text-white/60">
+            Contacto directo
+          </span>
+          <h2 class="text-3xl font-semibold text-white md:text-4xl">
+            Listo para potenciar tu próximo producto digital
+          </h2>
+          <p class="text-sm text-white/60">
+            Escríbeme y diseñemos juntos experiencias que conecten con tu audiencia.
+          </p>
+          <div class="flex flex-col gap-4 text-sm text-white/60">
+            <a class="group inline-flex items-center gap-3" href="mailto:hola@nicolas.dev">
+              <span class="h-2 w-2 rounded-full bg-accent"></span>
+              hola@nicolas.dev
+              <svg
+                class="h-4 w-4 -rotate-45 opacity-0 transition group-hover:translate-x-1 group-hover:opacity-100"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.8"
+                viewBox="0 0 24 24"
+              >
+                <path d="M5 12h14" />
+                <path d="m12 5 7 7-7 7" />
+              </svg>
+            </a>
+            <a class="group inline-flex items-center gap-3" href="https://cal.com">
+              <span class="h-2 w-2 rounded-full bg-accent"></span>
+              Agenda una llamada de descubrimiento
+              <svg
+                class="h-4 w-4 -rotate-45 opacity-0 transition group-hover:translate-x-1 group-hover:opacity-100"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.8"
+                viewBox="0 0 24 24"
+              >
+                <path d="M5 12h14" />
+                <path d="m12 5 7 7-7 7" />
+              </svg>
+            </a>
+          </div>
+        </div>
+        <form class="grid w-full max-w-md gap-5" data-animate="fade-up">
+          <div class="space-y-2">
+            <label class="text-xs font-mono uppercase tracking-[0.3em] text-white/40" for="nombre">Nombre</label>
+            <input
+              id="nombre"
+              type="text"
+              placeholder="¿Cómo te llamas?"
+              class="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-white/30 focus:border-accent/70 focus:outline-none focus:ring-2 focus:ring-accent/30"
+            />
+          </div>
+          <div class="space-y-2">
+            <label class="text-xs font-mono uppercase tracking-[0.3em] text-white/40" for="email">Email</label>
+            <input
+              id="email"
+              type="email"
+              placeholder="hola@empresa.com"
+              class="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-white/30 focus:border-accent/70 focus:outline-none focus:ring-2 focus:ring-accent/30"
+            />
+          </div>
+          <div class="space-y-2">
+            <label class="text-xs font-mono uppercase tracking-[0.3em] text-white/40" for="mensaje">Proyecto</label>
+            <textarea
+              id="mensaje"
+              rows="4"
+              placeholder="Cuéntame sobre tu producto, objetivos y timeline."
+              class="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-white/30 focus:border-accent/70 focus:outline-none focus:ring-2 focus:ring-accent/30"
+            ></textarea>
+          </div>
+          <button
+            type="submit"
+            class="group inline-flex items-center justify-center gap-3 rounded-full border border-transparent bg-white px-6 py-3 text-sm font-semibold text-midnight transition hover:-translate-y-1 hover:bg-secondary"
+          >
+            Enviar mensaje
+            <svg
+              class="h-4 w-4 -rotate-45 transition-transform duration-300 group-hover:translate-x-1"
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.8"
+              viewBox="0 0 24 24"
+            >
+              <path d="M5 12h14" />
+              <path d="m12 5 7 7-7 7" />
+            </svg>
+          </button>
+          <p class="text-xs text-white/40">
+            Al enviar aceptas la política de privacidad y recibir actualizaciones sobre mi disponibilidad.
+          </p>
+        </form>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/Experience.astro
+++ b/src/components/Experience.astro
@@ -1,0 +1,68 @@
+---
+const companies = [
+  {
+    period: '2022 — Presente',
+    company: 'Flowbase Studio',
+    role: 'Lead Product Designer',
+    description:
+      'Dirijo el diseño de productos SaaS para startups globales. Lidero procesos de discovery, prototipado y handoff con equipos multidisciplinarios.',
+    tags: ['Design Strategy', 'Design Systems', 'User Testing']
+  },
+  {
+    period: '2020 — 2022',
+    company: 'Northstar',
+    role: 'Senior UX/UI Designer',
+    description:
+      'Rediseño integral de aplicaciones financieras. Mejoré métricas de activación en un 35% mediante nuevas journeys y motion UI.',
+    tags: ['Fintech', 'Motion Design', 'Research']
+  },
+  {
+    period: '2018 — 2020',
+    company: 'Freelance',
+    role: 'Product Designer & Webflow Expert',
+    description:
+      'Creación de landing pages high-converting y dashboards complejos para startups seed-stage en LATAM y Europa.',
+    tags: ['SaaS', 'Startups', 'Branding']
+  }
+];
+---
+<section id="experiencia" class="relative py-28">
+  <div class="mx-auto max-w-6xl px-6">
+    <div class="mb-12 space-y-4">
+      <span class="text-xs font-mono uppercase tracking-[0.3em] text-white/40">Experiencia</span>
+      <h2 class="text-3xl font-semibold text-white md:text-4xl">Trayectoria y resultados comprobables</h2>
+      <p class="max-w-2xl text-sm text-white/60">
+        Cada etapa me permitió fortalecer la intersección entre diseño, producto y negocio. Aquí algunos hitos recientes.
+      </p>
+    </div>
+    <div class="relative border-l border-white/10 pl-10">
+      <div class="absolute left-0 top-0 -translate-x-1/2">
+        <span class="inline-flex h-3 w-3 rounded-full bg-accent shadow-glow"></span>
+      </div>
+      <div class="space-y-12">
+        {companies.map((item) => (
+          <article class="relative space-y-4" data-animate="fade-up">
+            <span class="absolute -left-10 top-1.5 flex h-6 w-6 -translate-x-1/2 items-center justify-center rounded-full border border-white/10 bg-charcoal text-[10px] font-semibold uppercase text-white/60">
+              ●
+            </span>
+            <p class="text-xs font-mono uppercase tracking-[0.35em] text-white/40">{item.period}</p>
+            <div class="flex flex-col gap-4 rounded-3xl border border-white/10 bg-charcoal/60 p-8">
+              <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                <h3 class="text-xl font-semibold text-white">{item.company}</h3>
+                <span class="text-sm text-white/50">{item.role}</span>
+              </div>
+              <p class="text-sm text-white/60">{item.description}</p>
+              <ul class="flex flex-wrap gap-3 text-xs font-medium text-white/60">
+                {item.tags.map((tag) => (
+                  <li class="rounded-full border border-white/10 bg-white/5 px-3 py-1" key={tag}>
+                    {tag}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,29 @@
+<footer class="border-t border-white/10 bg-charcoal/60">
+  <div class="mx-auto flex max-w-6xl flex-col gap-10 px-6 py-16 md:flex-row md:items-center md:justify-between">
+    <div>
+      <span class="text-xs font-mono uppercase tracking-[0.3em] text-white/40">Disponible para nuevos proyectos</span>
+      <h2 class="mt-3 text-3xl font-semibold text-white">Construyamos experiencias digitales memorables</h2>
+    </div>
+    <div class="flex flex-col gap-4 md:items-end">
+      <a
+        href="mailto:hola@nicolas.dev"
+        class="group inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-6 py-3 text-sm font-medium text-white transition hover:border-accent/60 hover:bg-accent/10"
+      >
+        <span>hola@nicolas.dev</span>
+        <svg
+          class="h-4 w-4 -rotate-45 transition-transform duration-300 group-hover:translate-x-1"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.8"
+          viewBox="0 0 24 24"
+        >
+          <path d="M5 12h14" />
+          <path d="m12 5 7 7-7 7" />
+        </svg>
+      </a>
+      <span class="text-xs text-white/40">© {new Date().getFullYear()} Nicolás Dev. Construido con Astro, Tailwind y GSAP.</span>
+    </div>
+  </div>
+</footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,53 @@
+---
+const navigation = [
+  { label: 'Servicios', href: '#servicios' },
+  { label: 'Experiencia', href: '#experiencia' },
+  { label: 'Proyectos', href: '#proyectos' },
+  { label: 'Acerca de', href: '#sobre-mi' },
+  { label: 'Contacto', href: '#contacto' }
+];
+---
+<header class="sticky top-0 z-30 bg-midnight/80 backdrop-blur-md border-b border-white/10">
+  <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-5">
+    <a href="#inicio" class="group inline-flex items-center gap-3">
+      <div class="relative h-11 w-11 overflow-hidden rounded-full border border-white/10">
+        <span class="absolute inset-0 bg-gradient-to-br from-accent/60 to-transparent transition-transform duration-500 group-hover:scale-110"></span>
+        <span class="absolute inset-[3px] rounded-full bg-charcoal"></span>
+        <span class="relative z-10 flex h-full w-full items-center justify-center text-sm font-semibold">ND</span>
+      </div>
+      <span class="text-sm font-mono uppercase tracking-[0.25em] text-white/60 transition-colors duration-300 group-hover:text-white">Nicolás Dev</span>
+    </a>
+    <nav class="hidden items-center gap-7 text-sm text-white/70 md:flex">
+      {navigation.map((item) => (
+        <a
+          class="relative font-medium tracking-wide transition duration-300 hover:text-white"
+          href={item.href}
+        >
+          {item.label}
+          <span class="absolute left-0 top-full mt-1 block h-[2px] w-0 bg-accent transition-all duration-300 group-hover:w-full md:group-hover:w-full"></span>
+        </a>
+      ))}
+    </nav>
+    <a
+      href="#contacto"
+      class="group inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-5 py-2 text-sm font-medium text-white transition hover:border-accent/50 hover:bg-accent/10"
+    >
+      <span>Hablemos</span>
+      <span class="relative inline-flex h-8 w-8 items-center justify-center overflow-hidden rounded-full border border-white/10">
+        <span class="absolute inset-0 bg-accent/30 transition-transform duration-500 group-hover:scale-110"></span>
+        <svg
+          class="relative z-10 h-4 w-4 -rotate-45"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.8"
+          viewBox="0 0 24 24"
+        >
+          <path d="M5 12h14" />
+          <path d="m12 5 7 7-7 7" />
+        </svg>
+      </span>
+    </a>
+  </div>
+</header>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,0 +1,107 @@
+<section id="inicio" class="relative overflow-hidden">
+  <div class="absolute inset-0 -z-10">
+    <div class="absolute -left-32 top-20 h-72 w-72 rounded-full bg-accent/20 blur-3xl"></div>
+    <div class="absolute -right-24 top-0 h-96 w-96 rounded-full bg-purple-500/10 blur-[120px]"></div>
+  </div>
+  <div class="mx-auto flex max-w-6xl flex-col gap-12 px-6 pb-32 pt-28 lg:flex-row lg:items-center lg:justify-between">
+    <div class="max-w-xl space-y-10">
+      <span
+        data-animate="badge"
+        class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-mono uppercase tracking-[0.4em] text-white/60"
+      >
+        Disponible para freelance
+        <span class="relative h-2 w-2">
+          <span class="absolute inset-0 rounded-full bg-emerald-400"></span>
+          <span class="absolute inset-0 animate-ping rounded-full bg-emerald-400"></span>
+        </span>
+      </span>
+      <h1 data-animate="headline" class="text-4xl font-semibold leading-[1.12] text-white sm:text-5xl lg:text-6xl">
+        <span class="block">Nicolás Dev</span>
+        <span class="block text-white/80">Product Designer & Webflow Expert</span>
+      </h1>
+      <p class="text-lg text-white/70">
+        Diseño interfaces digitales premium y experiencias web fluidas que impulsan marcas modernas.
+        Desde estrategias UX hasta implementaciones de Webflow y Astro.
+      </p>
+      <div class="flex flex-col gap-4 sm:flex-row">
+        <a
+          href="#proyectos"
+          class="group inline-flex items-center gap-3 rounded-full border border-transparent bg-white px-6 py-3 text-sm font-semibold text-midnight transition hover:-translate-y-1 hover:bg-secondary"
+        >
+          Ver proyectos
+          <svg
+            class="h-4 w-4 -rotate-45 transition-transform duration-300 group-hover:translate-x-1"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1.8"
+            viewBox="0 0 24 24"
+          >
+            <path d="M5 12h14" />
+            <path d="m12 5 7 7-7 7" />
+          </svg>
+        </a>
+        <a
+          href="#contacto"
+          class="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-6 py-3 text-sm font-semibold text-white transition hover:border-accent/60 hover:bg-accent/10"
+        >
+          Descargar CV
+          <svg
+            class="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1.8"
+            viewBox="0 0 24 24"
+          >
+            <path d="M12 5v14" />
+            <path d="m19 12-7 7-7-7" />
+          </svg>
+        </a>
+      </div>
+      <div class="grid gap-6 rounded-3xl border border-white/10 bg-charcoal/60 p-6 sm:grid-cols-3">
+        <div class="space-y-1">
+          <span class="text-xs font-mono uppercase tracking-[0.3em] text-white/40">Experiencia</span>
+          <p class="text-xl font-semibold text-white">8+ años</p>
+        </div>
+        <div class="space-y-1">
+          <span class="text-xs font-mono uppercase tracking-[0.3em] text-white/40">Clientes</span>
+          <p class="text-xl font-semibold text-white">Startup & Enterprise</p>
+        </div>
+        <div class="space-y-1">
+          <span class="text-xs font-mono uppercase tracking-[0.3em] text-white/40">Stack</span>
+          <p class="text-xl font-semibold text-white">Astro · Webflow · GSAP</p>
+        </div>
+      </div>
+    </div>
+    <div class="relative mx-auto w-full max-w-sm lg:mx-0">
+      <div class="relative rounded-[2.5rem] border border-white/10 bg-gradient-to-br from-charcoal via-charcoal to-midnight/40 p-6 shadow-2xl">
+        <div class="relative overflow-hidden rounded-[2rem] border border-white/10 bg-black/60 p-10">
+          <div class="absolute inset-x-10 top-10 h-48 rounded-full bg-gradient-to-b from-accent/30 via-transparent to-transparent blur-2xl"></div>
+          <div class="relative flex flex-col items-center gap-6 text-center" data-animate="avatar">
+            <div class="relative h-40 w-40 overflow-hidden rounded-full border border-white/10">
+              <div class="absolute inset-0 bg-gradient-to-br from-accent/40 via-transparent to-purple-500/20"></div>
+              <div class="absolute inset-[6px] rounded-full bg-[url('https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=400&q=80')] bg-cover bg-center"></div>
+            </div>
+            <div class="space-y-2">
+              <h2 class="text-2xl font-semibold text-white">Nicolás Dev</h2>
+              <p class="text-sm text-white/50">Product Designer | Webflow Expert</p>
+            </div>
+            <div class="grid w-full gap-3 text-left">
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs font-mono uppercase tracking-[0.3em] text-white/50">Especialidad</p>
+                <p class="mt-1 text-sm font-medium text-white">Productos SaaS & Plataformas No-Code</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs font-mono uppercase tracking-[0.3em] text-white/50">Ubicación</p>
+                <p class="mt-1 text-sm font-medium text-white">Remoto · Latinoamérica</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -1,0 +1,110 @@
+---
+const projects = [
+  {
+    name: 'Arcana Finance',
+    description: 'Plataforma DeFi enfocada en inversiones automatizadas. Rediseñé el onboarding, dashboards y marketing site.',
+    year: '2023',
+    link: '#',
+    thumbnail: 'https://images.unsplash.com/photo-1618005198919-d3d4b5a92eee?auto=format&fit=crop&w=1200&q=80',
+    tags: ['UX Strategy', 'Design System', 'Webflow']
+  },
+  {
+    name: 'Forma AI',
+    description: 'Aplicación SaaS para equipos de ventas. Construí componentes reutilizables y dashboards con métricas en tiempo real.',
+    year: '2022',
+    link: '#',
+    thumbnail: 'https://images.unsplash.com/photo-1618005198900-3dc8f9a6723c?auto=format&fit=crop&w=1200&q=80',
+    tags: ['Product Design', 'Motion', 'Front-end']
+  },
+  {
+    name: 'Marea Studio',
+    description: 'Sitio web inmersivo para estudio creativo. Implementación Webflow con animaciones complejas y CMS dinámico.',
+    year: '2021',
+    link: '#',
+    thumbnail: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80',
+    tags: ['Branding', 'Webflow', '3D Motion']
+  }
+];
+---
+<section id="proyectos" class="relative py-28">
+  <div class="absolute inset-x-0 top-0 -z-10 h-px bg-gradient-to-r from-transparent via-white/20 to-transparent"></div>
+  <div class="mx-auto max-w-6xl px-6">
+    <div class="mb-12 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+      <div>
+        <span class="text-xs font-mono uppercase tracking-[0.3em] text-white/40">Proyectos</span>
+        <h2 class="mt-4 text-3xl font-semibold text-white md:text-4xl">Selección de trabajos recientes</h2>
+      </div>
+      <a
+        href="#contacto"
+        class="inline-flex items-center gap-3 text-sm font-medium text-white/70 transition hover:text-white"
+      >
+        Ver todos los proyectos
+        <svg
+          class="h-4 w-4 -rotate-45"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.8"
+          viewBox="0 0 24 24"
+        >
+          <path d="M5 12h14" />
+          <path d="m12 5 7 7-7 7" />
+        </svg>
+      </a>
+    </div>
+    <div class="space-y-8">
+      {projects.map((project, index) => (
+        <article
+          data-animate="fade-up"
+          class={`relative overflow-hidden rounded-3xl border border-white/10 bg-charcoal/60 transition hover:border-accent/60 ${
+            index % 2 === 1 ? 'md:flex-row-reverse' : ''
+          }`}
+        >
+          <div class="grid gap-10 lg:grid-cols-[1.2fr_1fr]">
+            <figure class="relative overflow-hidden">
+              <img
+                src={project.thumbnail}
+                alt={project.name}
+                class="h-full w-full object-cover transition duration-700 hover:scale-105"
+                loading="lazy"
+              />
+            </figure>
+            <div class="flex flex-col justify-between gap-8 p-10">
+              <div class="space-y-4">
+                <span class="text-xs font-mono uppercase tracking-[0.3em] text-white/40">{project.year}</span>
+                <h3 class="text-3xl font-semibold text-white">{project.name}</h3>
+                <p class="text-sm text-white/60">{project.description}</p>
+              </div>
+              <div class="flex flex-wrap gap-3 text-xs text-white/60">
+                {project.tags.map((tag) => (
+                  <span class="rounded-full border border-white/10 bg-white/5 px-3 py-1" key={tag}>
+                    {tag}
+                  </span>
+                ))}
+              </div>
+              <a
+                href={project.link}
+                class="group inline-flex items-center gap-2 self-start text-sm font-medium text-white transition hover:text-accent"
+              >
+                Ver caso de estudio
+                <svg
+                  class="h-4 w-4 -rotate-45 transition-transform duration-300 group-hover:translate-x-1"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.8"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M5 12h14" />
+                  <path d="m12 5 7 7-7 7" />
+                </svg>
+              </a>
+            </div>
+          </div>
+        </article>
+      ))}
+    </div>
+  </div>
+</section>

--- a/src/components/ServiceGrid.astro
+++ b/src/components/ServiceGrid.astro
@@ -1,0 +1,57 @@
+---
+const services = [
+  {
+    title: 'Product Design',
+    description: 'Diseño productos digitales end-to-end, desde research, definición UX, hasta interfaces finales listas para desarrollo.',
+    highlights: ['Design Systems', 'UX Research', 'Prototipado interactivo']
+  },
+  {
+    title: 'No-Code Development',
+    description: 'Implementación de experiencias web complejas en Webflow y Astro, optimizadas para performance y SEO.',
+    highlights: ['Webflow Enterprise', 'Integraciones CMS', 'Automatizaciones']
+  },
+  {
+    title: 'Consultoría UX',
+    description: 'Acompaño equipos para alinear producto y negocio mediante workshops, roadmaps y auditorías de usabilidad.',
+    highlights: ['Workshops', 'Auditorías UX', 'Design Ops']
+  }
+];
+---
+<section id="servicios" class="relative py-28">
+  <div class="absolute inset-x-0 top-0 -z-10 h-px bg-gradient-to-r from-transparent via-white/20 to-transparent"></div>
+  <div class="mx-auto max-w-6xl px-6">
+    <div class="mb-12 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+      <div>
+        <span class="text-xs font-mono uppercase tracking-[0.3em] text-white/40">Servicios</span>
+        <h2 class="mt-4 text-3xl font-semibold text-white md:text-4xl">Experiencias digitales diseñadas a medida</h2>
+      </div>
+      <p class="max-w-xl text-sm text-white/60" data-animate="fade-up">
+        Cada proyecto es un mix entre estrategia, diseño y tecnología. Trabajo junto a startups y equipos de producto para lanzar experiencias memorables.
+      </p>
+    </div>
+    <div class="grid gap-6 md:grid-cols-3">
+      {services.map((service) => (
+        <article
+          data-animate="scale-in"
+          class="group h-full rounded-3xl border border-white/10 bg-charcoal/60 p-8 transition hover:border-accent/50 hover:bg-charcoal/80"
+        >
+          <div class="flex items-center justify-between">
+            <h3 class="text-xl font-semibold text-white">{service.title}</h3>
+            <span class="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-sm text-white/60 transition group-hover:border-accent/60 group-hover:bg-accent/20 group-hover:text-white">
+              {String(service.title).slice(0, 2)}
+            </span>
+          </div>
+          <p class="mt-6 text-sm leading-relaxed text-white/60">{service.description}</p>
+          <ul class="mt-6 space-y-3 text-sm text-white/70">
+            {service.highlights.map((item) => (
+              <li class="flex items-center gap-3" key={item}>
+                <span class="h-1.5 w-1.5 rounded-full bg-accent"></span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </article>
+      ))}
+    </div>
+  </div>
+</section>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,0 +1,25 @@
+---
+import '../styles/global.css';
+
+const { title = 'Nicolás - Product Designer', description = 'I craft immersive digital experiences that bridge aesthetics and functionality.' } = Astro.props;
+---
+<!DOCTYPE html>
+<html lang="es" class="scroll-smooth">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&family=Satoshi:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body class="bg-midnight font-sans text-secondary antialiased">
+    <slot />
+    <script type="module" src="/src/scripts/gsap-init.ts"></script>
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,23 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Hero from '../components/Hero.astro';
+import ServiceGrid from '../components/ServiceGrid.astro';
+import Experience from '../components/Experience.astro';
+import Projects from '../components/Projects.astro';
+import About from '../components/About.astro';
+import Contact from '../components/Contact.astro';
+import Footer from '../components/Footer.astro';
+---
+<BaseLayout>
+  <Header />
+  <main class="relative">
+    <Hero />
+    <ServiceGrid />
+    <Experience />
+    <Projects />
+    <About />
+    <Contact />
+  </main>
+  <Footer />
+</BaseLayout>

--- a/src/scripts/gsap-init.ts
+++ b/src/scripts/gsap-init.ts
@@ -1,0 +1,80 @@
+import { gsap } from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+
+const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+if (!prefersReducedMotion) {
+  const heroHeadline = document.querySelector('[data-animate="headline"]');
+  const heroBadge = document.querySelector('[data-animate="badge"]');
+  const heroAvatar = document.querySelector('[data-animate="avatar"]');
+
+  if (heroHeadline) {
+    gsap.fromTo(
+      heroHeadline.children,
+      { y: 60, opacity: 0 },
+      {
+        y: 0,
+        opacity: 1,
+        duration: 0.9,
+        stagger: 0.08,
+        ease: 'power3.out'
+      }
+    );
+  }
+
+  if (heroBadge) {
+    gsap.fromTo(
+      heroBadge,
+      { y: -40, opacity: 0 },
+      {
+        y: 0,
+        opacity: 1,
+        duration: 0.8,
+        ease: 'power2.out',
+        delay: 0.5
+      }
+    );
+  }
+
+  if (heroAvatar) {
+    gsap.fromTo(
+      heroAvatar,
+      { scale: 0.8, opacity: 0 },
+      {
+        scale: 1,
+        opacity: 1,
+        duration: 1,
+        ease: 'power3.out',
+        delay: 0.3
+      }
+    );
+  }
+
+  document.querySelectorAll('[data-animate="fade-up"]').forEach((element) => {
+    gsap.from(element, {
+      y: 60,
+      opacity: 0,
+      duration: 0.9,
+      ease: 'power3.out',
+      scrollTrigger: {
+        trigger: element,
+        start: 'top 80%'
+      }
+    });
+  });
+
+  document.querySelectorAll('[data-animate="scale-in"]').forEach((element) => {
+    gsap.from(element, {
+      scale: 0.85,
+      opacity: 0,
+      duration: 0.8,
+      ease: 'power2.out',
+      scrollTrigger: {
+        trigger: element,
+        start: 'top 85%'
+      }
+    });
+  });
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,16 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  background: radial-gradient(circle at top, rgba(91, 120, 246, 0.08), transparent 45%), #050505;
+}
+
+::selection {
+  background: rgba(91, 120, 246, 0.45);
+  color: #ffffff;
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,24 @@
+module.exports = {
+  content: [
+    './src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        midnight: '#0A0A0A',
+        charcoal: '#131313',
+        graphite: '#1F1F1F',
+        accent: '#5B78F6',
+        secondary: '#F1F1F1'
+      },
+      fontFamily: {
+        sans: ['"Satoshi"', '"Inter"', 'system-ui', 'sans-serif'],
+        mono: ['"IBM Plex Mono"', 'monospace']
+      },
+      boxShadow: {
+        glow: '0 0 60px rgba(91, 120, 246, 0.45)'
+      }
+    }
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "baseUrl": "./"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold an Astro project configured with Tailwind CSS and GSAP integrations
- rebuild the Nicolás Dev portfolio structure with hero, services, experience, projects, about, and contact sections
- add GSAP-driven entrance animations, global styling, and supporting assets like favicon and documentation

## Testing
- Not run (npm dependencies unavailable in offline environment)


------
https://chatgpt.com/codex/tasks/task_e_68e45a18a8a0832fb2b2f4a6e3f6c6c5